### PR TITLE
50 gdi access management service return 400 when attachment file is null

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/daam/api/ApplicationSubmissionExceptionMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/api/ApplicationSubmissionExceptionMapper.java
@@ -6,8 +6,6 @@ package io.github.genomicdatainfrastructure.daam.api;
 import io.github.genomicdatainfrastructure.daam.exceptions.ApplicationSubmissionException;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 
-import java.util.List;
-
 import io.github.genomicdatainfrastructure.daam.model.ErrorResponse;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/api/AttachmentFormatNotAcceptedExceptionMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/api/AttachmentFormatNotAcceptedExceptionMapper.java
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.daam.api;
+
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+
+import io.github.genomicdatainfrastructure.daam.exceptions.AttachmentFormatNotAcceptedException;
+import io.github.genomicdatainfrastructure.daam.model.ErrorResponse;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import java.util.List;
+
+@Provider
+public class AttachmentFormatNotAcceptedExceptionMapper implements
+        ExceptionMapper<AttachmentFormatNotAcceptedException> {
+
+    @Override
+    public Response toResponse(AttachmentFormatNotAcceptedException exception) {
+        var errorResponse = new ErrorResponse(
+                "Attachment Format Not Accepted",
+                BAD_REQUEST.getStatusCode(),
+                exception.getMessage(),
+                List.of()
+        );
+
+        return Response
+                .status(BAD_REQUEST)
+                .entity(errorResponse)
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/api/AttachmentIsNullExceptionMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/api/AttachmentIsNullExceptionMapper.java
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.daam.api;
+
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+
+import io.github.genomicdatainfrastructure.daam.exceptions.AttachmentIsNullException;
+import io.github.genomicdatainfrastructure.daam.model.ErrorResponse;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import java.util.List;
+
+@Provider
+public class AttachmentIsNullExceptionMapper implements ExceptionMapper<AttachmentIsNullException> {
+
+    @Override
+    public Response toResponse(AttachmentIsNullException exception) {
+        var errorResponse = new ErrorResponse(
+                "Attachment Is Null",
+                BAD_REQUEST.getStatusCode(),
+                exception.getMessage(),
+                List.of()
+        );
+
+        return Response
+                .status(BAD_REQUEST)
+                .entity(errorResponse)
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/api/AttachmentTooLargeExceptionMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/api/AttachmentTooLargeExceptionMapper.java
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.daam.api;
+
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+
+import io.github.genomicdatainfrastructure.daam.exceptions.AttachmentTooLargeException;
+import io.github.genomicdatainfrastructure.daam.model.ErrorResponse;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import java.util.List;
+
+@Provider
+public class AttachmentTooLargeExceptionMapper implements
+        ExceptionMapper<AttachmentTooLargeException> {
+
+    @Override
+    public Response toResponse(AttachmentTooLargeException exception) {
+        var errorResponse = new ErrorResponse(
+                "Attachment Too Large",
+                BAD_REQUEST.getStatusCode(),
+                exception.getMessage(),
+                List.of()
+        );
+
+        return Response
+                .status(BAD_REQUEST)
+                .entity(errorResponse)
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/exceptions/AttachmentFormatNotAcceptedException.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/exceptions/AttachmentFormatNotAcceptedException.java
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.daam.exceptions;
+
+import static java.lang.String.format;
+
+public class AttachmentFormatNotAcceptedException extends RuntimeException {
+
+    private static final String MESSAGE = "Format of file %s is not accepted";
+
+    public AttachmentFormatNotAcceptedException(String filename) {
+        super(format(MESSAGE, filename));
+    }
+}

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/exceptions/AttachmentIsNullException.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/exceptions/AttachmentIsNullException.java
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.daam.exceptions;
+
+public class AttachmentIsNullException extends RuntimeException {
+
+    private static final String MESSAGE = "Null file is not accepted";
+
+    public AttachmentIsNullException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/exceptions/AttachmentTooLargeException.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/exceptions/AttachmentTooLargeException.java
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.daam.exceptions;
+
+import static java.lang.String.format;
+
+public class AttachmentTooLargeException extends RuntimeException {
+
+    private static final String MESSAGE = "File %s is too big.";
+
+    public AttachmentTooLargeException(String filename) {
+        super(format(MESSAGE, filename));
+    }
+}

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/gateways/RemsApplicationMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/gateways/RemsApplicationMapper.java
@@ -8,9 +8,13 @@ import io.github.genomicdatainfrastructure.daam.model.*;
 import io.github.genomicdatainfrastructure.daam.remote.rems.model.*;
 import jakarta.enterprise.context.ApplicationScoped;
 
+import static java.util.Optional.ofNullable;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Comparator;
+import java.util.Objects;
 
 @ApplicationScoped
 public class RemsApplicationMapper {
@@ -63,7 +67,7 @@ public class RemsApplicationMapper {
     }
 
     private RetrievedApplicationWorkflow toWorkflow(Application application) {
-        var workflow = Optional.ofNullable(application
+        var workflow = ofNullable(application
                 .getApplicationWorkflow());
 
         return new RetrievedApplicationWorkflow(workflow.map(Response10953Workflow::getWorkflowId)
@@ -72,7 +76,7 @@ public class RemsApplicationMapper {
     }
 
     private RetrievedApplicationApplicant toApplicant(Application application) {
-        var applicant = Optional.ofNullable(application
+        var applicant = ofNullable(application
                 .getApplicationApplicant());
 
         return new RetrievedApplicationApplicant(
@@ -82,7 +86,7 @@ public class RemsApplicationMapper {
     }
 
     private List<RetrievedApplicationMember> toMembers(Application application) {
-        var potentialMembers = Optional.ofNullable(application
+        var potentialMembers = ofNullable(application
                 .getApplicationMembers());
 
         return potentialMembers.map(members -> members
@@ -93,7 +97,7 @@ public class RemsApplicationMapper {
     }
 
     private RetrievedApplicationMember toMember(UserWithAttributes member) {
-        var potentialMember = Optional.ofNullable(member);
+        var potentialMember = ofNullable(member);
 
         return new RetrievedApplicationMember(potentialMember.map(
                 UserWithAttributes::getUserid).orElse(null),
@@ -102,7 +106,7 @@ public class RemsApplicationMapper {
     }
 
     private List<RetrievedApplicationInvitedMember> toInvitedMembers(Application application) {
-        var potentialInvitedMembers = Optional.ofNullable(
+        var potentialInvitedMembers = ofNullable(
                 application.getApplicationInvitedMembers());
 
         return potentialInvitedMembers.map(invitedMembers -> invitedMembers
@@ -114,7 +118,7 @@ public class RemsApplicationMapper {
 
     private RetrievedApplicationInvitedMember toInvitedMember(
             Response10953InvitedMembers invitedMember) {
-        var potentialInvitedMember = Optional.ofNullable(invitedMember);
+        var potentialInvitedMember = ofNullable(invitedMember);
 
         return new RetrievedApplicationInvitedMember(
                 potentialInvitedMember.map(Response10953InvitedMembers::getName).orElse(
@@ -124,7 +128,7 @@ public class RemsApplicationMapper {
     }
 
     private List<ApplicationDataset> toDatasets(Application application) {
-        var potentialResources = Optional.ofNullable(application
+        var potentialResources = ofNullable(application
                 .getApplicationResources());
 
         return potentialResources
@@ -136,7 +140,7 @@ public class RemsApplicationMapper {
     }
 
     private ApplicationDataset toDataset(V2Resource resource) {
-        var potentialResource = Optional.ofNullable(resource);
+        var potentialResource = ofNullable(resource);
 
         return new ApplicationDataset(potentialResource.map(
                 V2Resource::getCatalogueItemId).orElse(null),
@@ -148,7 +152,7 @@ public class RemsApplicationMapper {
     }
 
     private List<RetrievedApplicationForm> toForms(Application application) {
-        var potentialForms = Optional.ofNullable(application
+        var potentialForms = ofNullable(application
                 .getApplicationForms());
 
         return potentialForms.map(forms -> forms
@@ -159,7 +163,7 @@ public class RemsApplicationMapper {
     }
 
     private RetrievedApplicationForm toForm(Form form) {
-        var potentialForm = Optional.ofNullable(form);
+        var potentialForm = ofNullable(form);
 
         return new RetrievedApplicationForm(potentialForm.map(Form::getFormId).orElse(null),
                 potentialForm.map(Form::getFormInternalName).orElse(null),
@@ -168,7 +172,7 @@ public class RemsApplicationMapper {
     }
 
     private List<RetrievedApplicationFormField> toFormFields(Form form) {
-        var potentialFields = Optional.ofNullable(form.getFormFields());
+        var potentialFields = ofNullable(form.getFormFields());
 
         return potentialFields.map(fields -> fields
                 .stream()
@@ -178,7 +182,7 @@ public class RemsApplicationMapper {
     }
 
     private RetrievedApplicationFormField toFormField(Field formField) {
-        var potentialFormField = Optional.ofNullable(formField);
+        var potentialFormField = ofNullable(formField);
 
         return new RetrievedApplicationFormField(potentialFormField.map(Field::getFieldId).orElse(
                 null),
@@ -198,8 +202,7 @@ public class RemsApplicationMapper {
     }
 
     private List<String> toPermissions(Application application) {
-        var potentialPermissions = Optional
-                .ofNullable(application.getApplicationPermissions());
+        var potentialPermissions = ofNullable(application.getApplicationPermissions());
 
         return potentialPermissions.map(permissions -> permissions
                 .stream()
@@ -209,25 +212,26 @@ public class RemsApplicationMapper {
     }
 
     private String toPermission(Application.ApplicationPermissionsEnum permission) {
-        var potentialPermission = Optional.ofNullable(permission);
+        var potentialPermission = ofNullable(permission);
 
         return potentialPermission.map(Application.ApplicationPermissionsEnum::value)
                 .orElse(null);
     }
 
     private List<RetrievedApplicationEvent> toEvents(Application application) {
-        var potentialEvents = Optional.ofNullable(application
-                .getApplicationEvents());
+        var potentialEvents = ofNullable(application.getApplicationEvents())
+                .orElseGet(List::of);
 
-        return potentialEvents.map(events -> events
+        return potentialEvents
                 .stream()
                 .map(this::toEvent)
-                .toList())
-                .orElse(null);
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(RetrievedApplicationEvent::getEventTime).reversed())
+                .toList();
     }
 
     private RetrievedApplicationEvent toEvent(Event event) {
-        var potentialEvent = Optional.ofNullable(event);
+        var potentialEvent = ofNullable(event);
 
         return new RetrievedApplicationEvent(
                 potentialEvent.map(this::toUserId).orElse(null),
@@ -236,14 +240,14 @@ public class RemsApplicationMapper {
     }
 
     private String toUserId(Event event) {
-        var eventActorAttributes = Optional.ofNullable(event
+        var eventActorAttributes = ofNullable(event
                 .getEventActorAttributes());
 
         return eventActorAttributes.map(UserWithAttributes::getUserid).orElse(null);
     }
 
     private List<RetrievedApplicationAttachment> toAttachments(Application application) {
-        var potentialAttachments = Optional.ofNullable(application
+        var potentialAttachments = ofNullable(application
                 .getApplicationAttachments());
 
         return potentialAttachments.map(attachments -> attachments
@@ -254,7 +258,7 @@ public class RemsApplicationMapper {
     }
 
     private RetrievedApplicationAttachment toAttachment(ApplicationAttachment attachment) {
-        var potentialAttachment = Optional.ofNullable(attachment);
+        var potentialAttachment = ofNullable(attachment);
 
         return new RetrievedApplicationAttachment(potentialAttachment.map(
                 ApplicationAttachment::getAttachmentId).orElse(null),
@@ -265,7 +269,7 @@ public class RemsApplicationMapper {
     }
 
     private List<RetrievedApplicationLicense> toLicences(Application application) {
-        var potentialLicenses = Optional.ofNullable(application
+        var potentialLicenses = ofNullable(application
                 .getApplicationLicenses());
 
         return potentialLicenses.map(licenses -> licenses
@@ -276,7 +280,7 @@ public class RemsApplicationMapper {
     }
 
     private RetrievedApplicationLicense toLicense(V2License license) {
-        var potentialLicense = Optional.ofNullable(license);
+        var potentialLicense = ofNullable(license);
 
         return new RetrievedApplicationLicense(
                 potentialLicense.map(this::toLicenseType)
@@ -290,14 +294,14 @@ public class RemsApplicationMapper {
     }
 
     private String toLicenseType(V2License license) {
-        var licenseType = Optional.ofNullable(license.getLicenseType());
+        var licenseType = ofNullable(license.getLicenseType());
 
         return licenseType.map(V2License.LicenseTypeEnum::value)
                 .orElse(null);
     }
 
     private RetrievedApplication.StateEnum toState(Application application) {
-        var potentialState = Optional.ofNullable(application
+        var potentialState = ofNullable(application
                 .getApplicationState());
 
         return potentialState.map(state -> RetrievedApplication.StateEnum.fromString(state.value()))

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/services/AttachFileToApplicationService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/services/AttachFileToApplicationService.java
@@ -4,18 +4,28 @@
 
 package io.github.genomicdatainfrastructure.daam.services;
 
+import static java.nio.file.Files.createTempFile;
+import static java.nio.file.Files.readAllBytes;
+import static java.nio.file.Files.write;
+
 import java.io.File;
-import java.nio.file.Files;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
+import io.github.genomicdatainfrastructure.daam.exceptions.AttachmentFormatNotAcceptedException;
+import io.github.genomicdatainfrastructure.daam.exceptions.AttachmentIsNullException;
+import io.github.genomicdatainfrastructure.daam.exceptions.AttachmentTooLargeException;
 import io.github.genomicdatainfrastructure.daam.gateways.RemsApiQueryGateway;
 import io.github.genomicdatainfrastructure.daam.model.AddedAttachment;
 import io.github.genomicdatainfrastructure.daam.remote.rems.api.RemsApplicationCommandApi;
 import io.github.genomicdatainfrastructure.daam.remote.rems.api.RemsApplicationCommandApi.ApiApplicationsAddAttachmentPostMultipartForm;
+import io.github.genomicdatainfrastructure.daam.remote.rems.model.AttachFileResponse;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response.Status;
+import lombok.SneakyThrows;
 
 @ApplicationScoped
 public class AttachFileToApplicationService {
@@ -38,26 +48,45 @@ public class AttachFileToApplicationService {
     public AddedAttachment attach(Long applicationId, String userId, String filename, File file) {
         gateway.checkIfApplicationIsEditableByUser(applicationId, userId);
 
-        var multipartForm = new ApiApplicationsAddAttachmentPostMultipartForm();
-        multipartForm._file = tempFile(filename, file);
-
-        var attachmentResponse = remsApplicationCommandApi.apiApplicationsAddAttachmentPost(
-                multipartForm, applicationId, remsApiKey, userId
-        );
+        var attachmentResponse = submitFileToRems(applicationId, userId, filename, file);
 
         return AddedAttachment.builder()
                 .id(attachmentResponse.getId())
                 .build();
     }
 
+    @SneakyThrows
     private File tempFile(String filename, File file) {
+        var tempFile = createTempFile(null, filename);
+        var content = readAllBytes(file.toPath());
+        write(tempFile, content);
+        return tempFile.toFile();
+    }
+
+    private AttachFileResponse submitFileToRems(
+            Long applicationId,
+            String userId,
+            String filename,
+            File file
+    ) {
+        if (filename == null || file == null) {
+            throw new AttachmentIsNullException();
+        }
+
+        var multipartForm = new ApiApplicationsAddAttachmentPostMultipartForm();
+        multipartForm._file = tempFile(filename, file);
         try {
-            var tempFile = Files.createTempFile(null, filename);
-            var content = Files.readAllBytes(file.toPath());
-            Files.write(tempFile, content);
-            return tempFile.toFile();
-        } catch (Exception e) {
-            throw new RuntimeException(e.getMessage(), e);
+            return remsApplicationCommandApi.apiApplicationsAddAttachmentPost(
+                    multipartForm, applicationId, remsApiKey, userId
+            );
+        } catch (WebApplicationException e) {
+            if (e.getResponse().getStatus() == Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode()) {
+                throw new AttachmentTooLargeException(multipartForm._file.getName());
+            }
+            if (e.getResponse().getStatus() == Status.UNSUPPORTED_MEDIA_TYPE.getStatusCode()) {
+                throw new AttachmentFormatNotAcceptedException(multipartForm._file.getName());
+            }
+            throw e;
         }
     }
 }

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/services/ListApplicationsService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/services/ListApplicationsService.java
@@ -7,8 +7,6 @@ package io.github.genomicdatainfrastructure.daam.services;
 import io.github.genomicdatainfrastructure.daam.gateways.RemsApiQueryGateway;
 import io.github.genomicdatainfrastructure.daam.gateways.RemsApplicationMapper;
 import io.github.genomicdatainfrastructure.daam.model.ListedApplication;
-import io.github.genomicdatainfrastructure.daam.remote.rems.model.ApplicationOverview;
-import io.github.genomicdatainfrastructure.daam.remote.rems.model.V2Resource;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import java.util.List;

--- a/src/main/openapi/daam.yaml
+++ b/src/main/openapi/daam.yaml
@@ -148,7 +148,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: "#/components/schemas/ErrorResponse"
+                $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: Application not found
           content:
@@ -296,14 +296,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AddedAttachment"
-        "404":
-          description: Application not found
+        "400":
+          description: Bad Request
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
         "403":
           description: Application does not belong to applicant
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Application not found
           content:
             application/json:
               schema:

--- a/src/main/openapi/rems.yaml
+++ b/src/main/openapi/rems.yaml
@@ -249,6 +249,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AttachFileResponse"
+        "413":
+          description: Attachment too large
+          content:
+            text/html:
+              schema:
+                type: string
+        "415":
+          description: Unsupported media type
+          content:
+            text/html:
+              schema:
+                type: string
   /api/applications/attachment/{attachment-id}:
     get:
       tags:

--- a/src/test/java/io/github/genomicdatainfrastructure/daam/services/AttachFileToApplicationServiceTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/daam/services/AttachFileToApplicationServiceTest.java
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.daam.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+
+import io.github.genomicdatainfrastructure.daam.exceptions.AttachmentFormatNotAcceptedException;
+import io.github.genomicdatainfrastructure.daam.exceptions.AttachmentIsNullException;
+import io.github.genomicdatainfrastructure.daam.exceptions.AttachmentTooLargeException;
+import io.github.genomicdatainfrastructure.daam.gateways.RemsApiQueryGateway;
+import io.github.genomicdatainfrastructure.daam.model.AddedAttachment;
+import io.github.genomicdatainfrastructure.daam.remote.rems.api.RemsApplicationCommandApi;
+import io.github.genomicdatainfrastructure.daam.remote.rems.model.AttachFileResponse;
+import jakarta.ws.rs.WebApplicationException;
+import lombok.SneakyThrows;
+
+class AttachFileToApplicationServiceTest {
+
+    private static final String REMS_API_KEY = "remsApiKey";
+    private AttachFileToApplicationService underTest;
+    private RemsApiQueryGateway gateway;
+    private RemsApplicationCommandApi remsApplicationCommandApi;
+
+    @BeforeEach
+    void setUp() {
+        gateway = mock(RemsApiQueryGateway.class);
+        remsApplicationCommandApi = mock(RemsApplicationCommandApi.class);
+        underTest = new AttachFileToApplicationService(
+                REMS_API_KEY,
+                remsApplicationCommandApi,
+                gateway
+        );
+    }
+
+    @Test
+    void can_attach() {
+        var applicationId = 1L;
+        var userId = "userId";
+        var attachment = attachment();
+
+        when(remsApplicationCommandApi.apiApplicationsAddAttachmentPost(
+                any(),
+                eq(applicationId),
+                eq(REMS_API_KEY),
+                eq(userId)
+        )).thenReturn(AttachFileResponse.builder().id(1L).build());
+
+        var actual = underTest.attach(applicationId, userId, attachment.getName(), attachment);
+
+        verify(gateway).checkIfApplicationIsEditableByUser(applicationId, userId);
+
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(AddedAttachment.builder()
+                        .id(1L)
+                        .build());
+    }
+
+    @Test
+    void throws_exception_if_filename_is_null() {
+        var applicationId = 1L;
+        var userId = "userId";
+        var attachment = attachment();
+
+        assertThrows(AttachmentIsNullException.class, () -> underTest.attach(
+                applicationId, userId, null, attachment
+        ));
+
+        verify(gateway).checkIfApplicationIsEditableByUser(applicationId, userId);
+    }
+
+    @Test
+    void throws_exception_if_file_is_null() {
+        var applicationId = 1L;
+        var userId = "userId";
+
+        assertThrows(AttachmentIsNullException.class, () -> underTest.attach(
+                applicationId, userId, "not_null.txt", null
+        ));
+
+        verify(gateway).checkIfApplicationIsEditableByUser(applicationId, userId);
+    }
+
+    @Test
+    void throws_exception_if_remote_request_entity_too_large() {
+        var applicationId = 1L;
+        var userId = "userId";
+        var attachment = attachment();
+
+        when(remsApplicationCommandApi.apiApplicationsAddAttachmentPost(
+                any(),
+                eq(applicationId),
+                eq(REMS_API_KEY),
+                eq(userId)
+        )).thenThrow(new WebApplicationException(413));
+
+        assertThrows(AttachmentTooLargeException.class, () -> underTest.attach(
+                applicationId, userId, attachment.getName(), attachment
+        ));
+
+        verify(gateway).checkIfApplicationIsEditableByUser(applicationId, userId);
+    }
+
+    @Test
+    void throws_exception_if_remote_unsupported_media_type() {
+        var applicationId = 1L;
+        var userId = "userId";
+        var attachment = attachment();
+
+        when(remsApplicationCommandApi.apiApplicationsAddAttachmentPost(
+                any(),
+                eq(applicationId),
+                eq(REMS_API_KEY),
+                eq(userId)
+        )).thenThrow(new WebApplicationException(415));
+
+        assertThrows(AttachmentFormatNotAcceptedException.class, () -> underTest.attach(
+                applicationId, userId, attachment.getName(), attachment
+        ));
+
+        verify(gateway).checkIfApplicationIsEditableByUser(applicationId, userId);
+    }
+
+    @Test
+    void throws_not_expected_exception() {
+        var applicationId = 1L;
+        var userId = "userId";
+        var attachment = attachment();
+
+        when(remsApplicationCommandApi.apiApplicationsAddAttachmentPost(
+                any(),
+                eq(applicationId),
+                eq(REMS_API_KEY),
+                eq(userId)
+        )).thenThrow(new WebApplicationException(400));
+
+        assertThrows(WebApplicationException.class, () -> underTest.attach(
+                applicationId, userId, attachment.getName(), attachment
+        ));
+
+        verify(gateway).checkIfApplicationIsEditableByUser(applicationId, userId);
+    }
+
+    @SneakyThrows
+    private File attachment() {
+        var classLoader = getClass().getClassLoader();
+        return new File(classLoader.getResource("dummy.txt").getFile());
+    }
+}


### PR DESCRIPTION
REMS throws 415 if the file format is not accepted. It also throws 413 if file is too big, not were are managing those remote error.

An extra validation was added, if file or filename is null, we throw expected exception.

Another tiny change on this PR, we are sorting application events by time desc.