### PR TITLE
fix: structuring ErrorMessages before sending them to frontend

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/daam/exceptions/ApplicationSubmissionException.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/exceptions/ApplicationSubmissionException.java
@@ -11,7 +11,7 @@ public class ApplicationSubmissionException extends RuntimeException {
     private final List<String> errorMessages;
 
     public ApplicationSubmissionException(Long applicationId, List<String> errorMessages) {
-        super(String.format(MESSAGE, applicationId, String.join("\n", errorMessages)));
+        super(String.format(MESSAGE, applicationId));
         this.errorMessages = errorMessages;
     }
 

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/exceptions/ApplicationSubmissionException.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/exceptions/ApplicationSubmissionException.java
@@ -7,11 +7,11 @@ import java.util.List;
 
 public class ApplicationSubmissionException extends RuntimeException {
 
-    private static final String MESSAGE = "Application %s could not be submitted.";
+    private static final String MESSAGE = "Application %s could not be submitted due to the following errors:";
     private final List<String> errorMessages;
 
     public ApplicationSubmissionException(Long applicationId, List<String> errorMessages) {
-        super(String.format(MESSAGE, applicationId));
+        super(String.format(MESSAGE, applicationId, String.join("\n", errorMessages)));
         this.errorMessages = errorMessages;
     }
 

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/services/SubmitApplicationService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/services/SubmitApplicationService.java
@@ -31,6 +31,14 @@ public class SubmitApplicationService {
         this.gateway = remsApiQueryGateway;
     }
 
+    private String formatError(String error) {
+        return switch (error) {
+            case "t.form.validation/required" -> "is required.";
+            case "t.form.validation/format_error" -> "has invalid format.";
+            default -> "encountered an unknown error.";
+        };
+    }
+
     public void submitApplication(Long id, String userId) {
         gateway.checkIfApplicationIsEditableByUser(id, userId);
 
@@ -44,7 +52,8 @@ public class SubmitApplicationService {
 
         if (Boolean.FALSE.equals(response.getSuccess())) {
             throw new ApplicationSubmissionException(id, response.getErrors().stream().map(
-                    error -> error.getFieldId() + " " + error.getType() + " " + error.getFormId())
+                    error -> "Field " + error.getFieldId() + " " + formatError(error
+                            .getType()))
                     .toList());
         }
     }


### PR DESCRIPTION
## 🚀 Pull Request Checklist

- **Title:** 
  Structuring ErrorMessages from Submission exception
- **Description:**
Error Messages were send almost in a raw form to the frontend, hence we formatted them so when these error Messages are fetched in the frontend, they can be ready to be displayed.