### PR TITLE
fix: replace REMS warning type from string to ValidationField

### DIFF
--- a/src/main/openapi/rems.yaml
+++ b/src/main/openapi/rems.yaml
@@ -1293,7 +1293,7 @@ components:
         warnings:
           type: array
           items:
-            type: string
+            $ref: "#/components/schemas/ValidationField"
         application-id:
           type: integer
           format: int64

--- a/src/test/resources/mappings/save_application.json
+++ b/src/test/resources/mappings/save_application.json
@@ -9,7 +9,19 @@
             "Content-Type": "application/json"
         },
         "jsonBody": {
-            "success": true
+            "success": true,
+            "warnings": [
+                {
+                    "field-id": "fld3",
+                    "type": "t.form.validation/required",
+                    "form-id": 14
+                },
+                {
+                    "field-id": "fld5",
+                    "type": "t.form.validation/required",
+                    "form-id": 14
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the REMS API schema by changing the warning type from a string to a ValidationField, ensuring proper validation and data structure consistency.

Bug Fixes:
- Replace the warning type from a string to a ValidationField in the REMS API schema to ensure correct data structure.

<!-- Generated by sourcery-ai[bot]: end summary -->