### PR TITLE
chore: make user id claim configurable

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/daam/api/ApplicationQueryApiImpl.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/api/ApplicationQueryApiImpl.java
@@ -10,19 +10,29 @@ import io.github.genomicdatainfrastructure.daam.services.ListApplicationsService
 import io.github.genomicdatainfrastructure.daam.services.RetrieveApplicationService;
 import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
 import io.quarkus.security.identity.SecurityIdentity;
-import lombok.RequiredArgsConstructor;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.resteasy.reactive.multipart.FileUpload;
 
 import java.util.List;
 
-import static io.github.genomicdatainfrastructure.daam.security.PostAuthenticationFilter.USER_ID_CLAIM;
-
-@RequiredArgsConstructor
 public class ApplicationQueryApiImpl implements ApplicationQueryApi {
 
     private final SecurityIdentity identity;
     private final ListApplicationsService listApplicationsService;
     private final RetrieveApplicationService retrieveApplicationService;
+    private final String userIdClaim;
+
+    public ApplicationQueryApiImpl(
+            SecurityIdentity identity,
+            ListApplicationsService listApplicationsService,
+            RetrieveApplicationService retrieveApplicationService,
+            @ConfigProperty(name = "quarkus.rest-client.rems_yaml.user-id-claim") String userIdClaim
+    ) {
+        this.identity = identity;
+        this.listApplicationsService = listApplicationsService;
+        this.retrieveApplicationService = retrieveApplicationService;
+        this.userIdClaim = userIdClaim;
+    }
 
     @Override
     public List<ListedApplication> listApplicationsV1() {
@@ -43,6 +53,6 @@ public class ApplicationQueryApiImpl implements ApplicationQueryApi {
 
     private String userId() {
         var principal = (OidcJwtCallerPrincipal) identity.getPrincipal();
-        return principal.getClaim(USER_ID_CLAIM);
+        return principal.getClaim(userIdClaim);
     }
 }

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/api/EntitlementQueryApiImpl.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/api/EntitlementQueryApiImpl.java
@@ -8,16 +8,23 @@ import io.github.genomicdatainfrastructure.daam.model.RetrieveGrantedDatasetIden
 import io.github.genomicdatainfrastructure.daam.services.RetrieveGrantedDatasetIdentifiersService;
 import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
 import io.quarkus.security.identity.SecurityIdentity;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import lombok.RequiredArgsConstructor;
-
-import static io.github.genomicdatainfrastructure.daam.security.PostAuthenticationFilter.USER_ID_CLAIM;
-
-@RequiredArgsConstructor
 public class EntitlementQueryApiImpl implements EntitlementQueryApi {
 
     private final SecurityIdentity identity;
     private final RetrieveGrantedDatasetIdentifiersService retrieveGrantedDatasetIdentifiersService;
+    private final String userIdClaim;
+
+    public EntitlementQueryApiImpl(
+            SecurityIdentity identity,
+            RetrieveGrantedDatasetIdentifiersService retrieveGrantedDatasetIdentifiersService,
+            @ConfigProperty(name = "quarkus.rest-client.rems_yaml.user-id-claim") String userIdClaim
+    ) {
+        this.identity = identity;
+        this.retrieveGrantedDatasetIdentifiersService = retrieveGrantedDatasetIdentifiersService;
+        this.userIdClaim = userIdClaim;
+    }
 
     @Override
     public RetrieveGrantedDatasetIdentifiers retrieveGrantedDatasetIdentifiers() {
@@ -26,6 +33,6 @@ public class EntitlementQueryApiImpl implements EntitlementQueryApi {
 
     private String userId() {
         var principal = (OidcJwtCallerPrincipal) identity.getPrincipal();
-        return principal.getClaim(USER_ID_CLAIM);
+        return principal.getClaim(userIdClaim);
     }
 }

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/security/PostAuthenticationFilter.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/security/PostAuthenticationFilter.java
@@ -12,24 +12,28 @@ import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.ext.Provider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @Provider
 @Priority(Priorities.AUTHENTICATION)
 public class PostAuthenticationFilter implements ContainerRequestFilter {
 
-    public static final String USER_ID_CLAIM = "elixir_id";
     public static final String USER_NAME_CLAIM = "preferred_username";
     public static final String EMAIL_CLAIM = "email";
 
     private final SecurityIdentity identity;
     private final CreateRemsUserService createRemsUserService;
+    private final String userIdClaim;
 
     @Inject
-    public PostAuthenticationFilter(SecurityIdentity identity,
-            CreateRemsUserService createRemsUserService
+    public PostAuthenticationFilter(
+            SecurityIdentity identity,
+            CreateRemsUserService createRemsUserService,
+            @ConfigProperty(name = "quarkus.rest-client.rems_yaml.user-id-claim") String userIdClaim
     ) {
         this.identity = identity;
         this.createRemsUserService = createRemsUserService;
+        this.userIdClaim = userIdClaim;
     }
 
     @Override
@@ -38,7 +42,7 @@ public class PostAuthenticationFilter implements ContainerRequestFilter {
             var oidcPrincipal = (OidcJwtCallerPrincipal) identity.getPrincipal();
 
             createRemsUserService.createRemsUser(
-                    oidcPrincipal.getClaim(USER_ID_CLAIM),
+                    oidcPrincipal.getClaim(userIdClaim),
                     oidcPrincipal.getClaim(USER_NAME_CLAIM),
                     oidcPrincipal.getClaim(EMAIL_CLAIM)
             );

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,7 @@ quarkus.openapi-generator.codegen.spec.rems_yaml.generate-part-filename=false
 quarkus.rest-client.rems_yaml.api-key=42
 quarkus.rest-client.rems_yaml.bot-user=owner
 quarkus.rest-client.rems_yaml.url=http://localhost:4000
+quarkus.rest-client.rems_yaml.user-id-claim=elixir_id
 quarkus.keycloak.devservices.realm-path=quarkus-realm.json
 quarkus.keycloak.devservices.port=32794
 quarkus.wiremock.devservices.port=4000

--- a/src/test/java/io/github/genomicdatainfrastructure/daam/security/PostAuthenticationFilterTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/daam/security/PostAuthenticationFilterTest.java
@@ -27,8 +27,8 @@ class PostAuthenticationFilterTest {
     private CreateRemsUserService createRemsUserService;
 
     @BeforeEach
-    private void setUp() {
-        underTest = new PostAuthenticationFilter(securityIdentity, createRemsUserService);
+    void setUp() {
+        underTest = new PostAuthenticationFilter(securityIdentity, createRemsUserService, "sub");
     }
 
     @Test
@@ -44,7 +44,7 @@ class PostAuthenticationFilterTest {
 
         var principalMock = mock(OidcJwtCallerPrincipal.class);
 
-        when(principalMock.getClaim("elixir_id")).thenReturn("dummy_id");
+        when(principalMock.getClaim("sub")).thenReturn("dummy_id");
         when(principalMock.getClaim("preferred_username")).thenReturn("dummy_username");
         when(principalMock.getClaim("email")).thenReturn("dummy_email");
         when(securityIdentity.getPrincipal()).thenReturn(principalMock);


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce configurability for the user ID claim by replacing the hardcoded 'USER_ID_CLAIM' with a configurable property 'userIdClaim' across multiple API implementations and the PostAuthenticationFilter.

Enhancements:
- Make the user ID claim configurable by introducing a new configuration property 'quarkus.rest-client.rems_yaml.user-id-claim'.

<!-- Generated by sourcery-ai[bot]: end summary -->