### PR TITLE
fix: get userIdClaim variable at runtime

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/daam/security/PostAuthenticationFilter.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/security/PostAuthenticationFilter.java
@@ -12,9 +12,7 @@ import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.ext.Provider;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-import java.util.Optional;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 import static io.github.genomicdatainfrastructure.daam.api.ApplicationQueryApiImpl.DEFAULT_USER_ID_CLAIM;
 
@@ -27,22 +25,22 @@ public class PostAuthenticationFilter implements ContainerRequestFilter {
 
     private final SecurityIdentity identity;
     private final CreateRemsUserService createRemsUserService;
-    private final Optional<String> userIdClaim;
 
     @Inject
     public PostAuthenticationFilter(
             SecurityIdentity identity,
-            CreateRemsUserService createRemsUserService,
-            @ConfigProperty(name = "quarkus.rest-client.rems_yaml.user-id-claim") Optional<String> userIdClaim
+            CreateRemsUserService createRemsUserService
     ) {
         this.identity = identity;
         this.createRemsUserService = createRemsUserService;
-        this.userIdClaim = userIdClaim;
     }
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
         if (!identity.isAnonymous()) {
+            var userIdClaim = ConfigProvider.getConfig().getOptionalValue(
+                    "quarkus.rest-client.rems_yaml.user-id-claim", String.class);
+
             var oidcPrincipal = (OidcJwtCallerPrincipal) identity.getPrincipal();
 
             createRemsUserService.createRemsUser(

--- a/src/test/java/io/github/genomicdatainfrastructure/daam/security/PostAuthenticationFilterTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/daam/security/PostAuthenticationFilterTest.java
@@ -12,7 +12,6 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static java.util.Optional.of;
 import static org.mockito.Mockito.*;
 
 @QuarkusTest
@@ -29,8 +28,7 @@ class PostAuthenticationFilterTest {
 
     @BeforeEach
     void setUp() {
-        underTest = new PostAuthenticationFilter(securityIdentity, createRemsUserService, of(
-                "sub"));
+        underTest = new PostAuthenticationFilter(securityIdentity, createRemsUserService);
     }
 
     @Test
@@ -46,7 +44,7 @@ class PostAuthenticationFilterTest {
 
         var principalMock = mock(OidcJwtCallerPrincipal.class);
 
-        when(principalMock.getClaim("sub")).thenReturn("dummy_id");
+        when(principalMock.getClaim("elixir_id")).thenReturn("dummy_id");
         when(principalMock.getClaim("preferred_username")).thenReturn("dummy_username");
         when(principalMock.getClaim("email")).thenReturn("dummy_email");
         when(securityIdentity.getPrincipal()).thenReturn(principalMock);


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the retrieval of the userIdClaim variable by obtaining it at runtime, ensuring dynamic configuration values are used. Update the corresponding test to align with the constructor changes.

Bug Fixes:
- Retrieve the userIdClaim variable at runtime instead of injecting it, ensuring the correct value is used during each request.

Tests:
- Update the PostAuthenticationFilterTest to reflect the changes in the PostAuthenticationFilter constructor by removing the userIdClaim parameter.

<!-- Generated by sourcery-ai[bot]: end summary -->