### PR TITLE
Feat/delete draft action

### DIFF
--- a/src/main/java/io/github/genomicdatainfrastructure/daam/api/ApplicationCommandApiImpl.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/api/ApplicationCommandApiImpl.java
@@ -21,6 +21,7 @@ public class ApplicationCommandApiImpl implements ApplicationCommandApi {
     private final SaveApplicationService saveApplicationService;
     private final CreateApplicationService createApplicationService;
     private final SubmitApplicationService submitApplicationService;
+    private final DeleteApplicationService deleteApplicationService;
     private final AttachFileToApplicationService attachFileToApplicationService;
     private final AcceptTermsService acceptTermsService;
     private final Optional<String> userIdClaim;
@@ -30,6 +31,7 @@ public class ApplicationCommandApiImpl implements ApplicationCommandApi {
             SaveApplicationService saveApplicationService,
             CreateApplicationService createApplicationService,
             SubmitApplicationService submitApplicationService,
+            DeleteApplicationService deleteApplicationService,
             AttachFileToApplicationService attachFileToApplicationService,
             AcceptTermsService acceptTermsService,
             @ConfigProperty(name = "quarkus.rest-client.rems_yaml.user-id-claim") Optional<String> userIdClaim
@@ -38,6 +40,7 @@ public class ApplicationCommandApiImpl implements ApplicationCommandApi {
         this.saveApplicationService = saveApplicationService;
         this.createApplicationService = createApplicationService;
         this.submitApplicationService = submitApplicationService;
+        this.deleteApplicationService = deleteApplicationService;
         this.attachFileToApplicationService = attachFileToApplicationService;
         this.acceptTermsService = acceptTermsService;
         this.userIdClaim = userIdClaim;
@@ -70,6 +73,12 @@ public class ApplicationCommandApiImpl implements ApplicationCommandApi {
                 userId());
 
         return new CreateApplicationResponse().applicationId(applicationId);
+    }
+
+    @java.lang.Override
+    public Response deleteApplicationV1(Long id) {
+        deleteApplicationService.deleteApplication(id, userId());
+        return Response.noContent().build();
     }
 
     @Override

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/api/ApplicationNotInCorrectStateExceptionMapper.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/api/ApplicationNotInCorrectStateExceptionMapper.java
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.genomicdatainfrastructure.daam.api;
 
-import static jakarta.ws.rs.core.Response.Status.PRECONDITION_REQUIRED;
+import static jakarta.ws.rs.core.Response.Status.CONFLICT;
 
 import java.util.List;
 
@@ -22,13 +22,13 @@ public class ApplicationNotInCorrectStateExceptionMapper implements
     public Response toResponse(ApplicationNotInCorrectStateException exception) {
         var errorResponse = new ErrorResponse(
                 "Application Not In Correct State",
-                PRECONDITION_REQUIRED.getStatusCode(),
+                CONFLICT.getStatusCode(),
                 exception.getMessage(),
                 List.of()
         );
 
         return Response
-                .status(PRECONDITION_REQUIRED)
+                .status(CONFLICT)
                 .entity(errorResponse)
                 .type(MediaType.APPLICATION_JSON)
                 .build();

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/gateways/RemsApiQueryGateway.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/gateways/RemsApiQueryGateway.java
@@ -83,6 +83,20 @@ public class RemsApiQueryGateway {
         }
     }
 
+    public void checkIfApplicationIsDeletableByUser(Long id, String userId) {
+        var application = retrieveApplication(id, userId);
+
+        if (!application.getApplicationApplicant().getUserid().equals(userId)) {
+            throw new UserNotApplicantException(userId);
+        }
+
+        if (application.getApplicationState() != ApplicationStateEnum.DRAFT) {
+            throw new ApplicationNotInCorrectStateException(
+                    application.getApplicationState().value()
+            );
+        }
+    }
+
     public CatalogueItem retrieveCatalogueItemByResourceId(String userId, String resourceId) {
         var items = catalogueItemApi.apiCatalogueItemsGet(remsApiKey, userId, resourceId);
         if (items.isEmpty()) {

--- a/src/main/java/io/github/genomicdatainfrastructure/daam/services/DeleteApplicationService.java
+++ b/src/main/java/io/github/genomicdatainfrastructure/daam/services/DeleteApplicationService.java
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.daam.services;
+
+import io.github.genomicdatainfrastructure.daam.gateways.RemsApiQueryGateway;
+import io.github.genomicdatainfrastructure.daam.remote.rems.api.RemsApplicationCommandApi;
+import io.github.genomicdatainfrastructure.daam.remote.rems.model.DeleteApplicationCommand;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@ApplicationScoped
+public class DeleteApplicationService {
+
+    private static final String DELETION_LOG = "%s failed to delete application %s: %s";
+    private final String remsApiKey;
+    private final RemsApplicationCommandApi remsApplicationCommandApi;
+    private final RemsApiQueryGateway gateway;
+
+    @Inject
+    public DeleteApplicationService(
+            @ConfigProperty(name = "quarkus.rest-client.rems_yaml.api-key") String remsApiKey,
+            @RestClient RemsApplicationCommandApi remsApplicationCommandApi,
+            RemsApiQueryGateway apiQueryGateway
+    ) {
+        this.remsApiKey = remsApiKey;
+        this.remsApplicationCommandApi = remsApplicationCommandApi;
+        this.gateway = apiQueryGateway;
+    }
+
+    public void deleteApplication(Long applicationId, String userId) {
+        gateway.checkIfApplicationIsDeletableByUser(applicationId, userId);
+
+        var command = DeleteApplicationCommand
+                .builder()
+                .applicationId(applicationId)
+                .build();
+
+        remsApplicationCommandApi.apiApplicationsDeletePost(remsApiKey,
+                userId,
+                command);
+    }
+}

--- a/src/main/openapi/daam.yaml
+++ b/src/main/openapi/daam.yaml
@@ -85,6 +85,43 @@ paths:
       security:
         - daam_auth:
             - read:applications
+    delete:
+      summary: Delete application
+      operationId: delete_application_v1
+      tags:
+        - "application-command"
+      parameters:
+        - name: id
+          in: path
+          description: ID of application to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "204":
+          description: Successful Response (no content)
+        "403":
+          description: Application does not belong to applicant
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Application not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Application not in draft state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      security:
+        - daam_auth:
+            - read:applications
   /api/v1/applications/{id}/save-forms-and-duos:
     post:
       summary: save application forms and duos
@@ -119,7 +156,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "428":
+        "409":
           description: Application not in submittable state
           content:
             application/json:
@@ -163,7 +200,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "428":
+        "409":
           description: Application not in submittable state
           content:
             application/json:
@@ -288,7 +325,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "428":
+        "409":
           description: Application not in submittable state
           content:
             application/json:
@@ -346,7 +383,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "428":
+        "409":
           description: Application not in submittable state
           content:
             application/json:

--- a/src/main/openapi/rems.yaml
+++ b/src/main/openapi/rems.yaml
@@ -358,7 +358,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DeleteDraftCommand"
+              $ref: "#/components/schemas/DeleteApplicationCommand"
         required: true
       responses:
         "200":
@@ -1537,15 +1537,12 @@ components:
       properties:
         organization/id:
           type: string
-    DeleteDraftCommand:
+    DeleteApplicationCommand:
       type: object
       properties:
         application-id:
           type: integer
           format: int64
-        expires-on:
-          type: string
-          format: date-time
       required:
         - application-id
     AcceptLicensesCommand:

--- a/src/main/openapi/rems.yaml
+++ b/src/main/openapi/rems.yaml
@@ -336,6 +336,37 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SuccessApplicationResponse"
+  /api/applications/delete:
+    post:
+      tags:
+        - rems-application-command
+      summary: "Submit a `delete` command for an application. Only drafts can be deleted. Only applications can delete drafts. (roles: logged-in)"
+      parameters:
+        - name: x-rems-api-key
+          required: true
+          in: header
+          description: REMS API-Key (optional for UI, required for API)
+          schema:
+            type: string
+        - name: x-rems-user-id
+          required: true
+          in: header
+          description: user (optional for UI, required for API). This can be a REMS internal or an external user identity attribute (specified in config.edn).
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeleteDraftCommand"
+        required: true
+      responses:
+        "200":
+          description: Attachment addition successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessApplicationResponse"
   /api/entitlements:
     get:
       tags:
@@ -1506,6 +1537,17 @@ components:
       properties:
         organization/id:
           type: string
+    DeleteDraftCommand:
+      type: object
+      properties:
+        application-id:
+          type: integer
+          format: int64
+        expires-on:
+          type: string
+          format: date-time
+      required:
+        - application-id
     AcceptLicensesCommand:
       type: object
       required:

--- a/src/test/java/io/github/genomicdatainfrastructure/daam/api/AcceptTermsTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/daam/api/AcceptTermsTest.java
@@ -69,7 +69,7 @@ class AcceptTermsTest extends BaseTest {
                 .when()
                 .post("/api/v1/applications/2/accept-terms")
                 .then()
-                .statusCode(428)
+                .statusCode(409)
                 .body("title", equalTo("Application Not In Correct State"));
     }
 

--- a/src/test/java/io/github/genomicdatainfrastructure/daam/api/AttachFileToApplicationTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/daam/api/AttachFileToApplicationTest.java
@@ -63,7 +63,7 @@ class AttachFileToApplicationTest extends BaseTest {
                 .when()
                 .post("/api/v1/applications/2/attachments")
                 .then()
-                .statusCode(428);
+                .statusCode(409);
     }
 
     @Test

--- a/src/test/java/io/github/genomicdatainfrastructure/daam/api/DeleteApplicationIT.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/daam/api/DeleteApplicationIT.java
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.daam.api;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class DeleteApplicationIT extends DeleteApplicationTest {
+}

--- a/src/test/java/io/github/genomicdatainfrastructure/daam/api/DeleteApplicationTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/daam/api/DeleteApplicationTest.java
@@ -8,6 +8,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
 class DeleteApplicationTest extends BaseTest {
@@ -31,7 +32,9 @@ class DeleteApplicationTest extends BaseTest {
                 .when()
                 .delete("/api/v1/applications/12345")
                 .then()
-                .statusCode(404);
+                .statusCode(404)
+                .body("title", equalTo("Application Not Found"))
+                .body("detail", equalTo("The application was not found."));
     }
 
     @Test
@@ -42,7 +45,8 @@ class DeleteApplicationTest extends BaseTest {
                 .when()
                 .delete("/api/v1/applications/1")
                 .then()
-                .statusCode(403);
+                .statusCode(403)
+                .body("title", equalTo("User Not Applicant"));
     }
 
     @Test
@@ -53,7 +57,10 @@ class DeleteApplicationTest extends BaseTest {
                 .when()
                 .delete("/api/v1/applications/2")
                 .then()
-                .statusCode(409);
+                .statusCode(409)
+                .body("title", equalTo("Application Not In Correct State"))
+                .body("detail", equalTo(
+                        "The application is not in correct state: application.state/submitted."));
     }
 
     @Test

--- a/src/test/java/io/github/genomicdatainfrastructure/daam/api/DeleteApplicationTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/daam/api/DeleteApplicationTest.java
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.genomicdatainfrastructure.daam.api;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+class DeleteApplicationTest extends BaseTest {
+
+    @Test
+    void can_delete_draft_application() {
+        given()
+                .auth()
+                .oauth2(getAccessToken("alice"))
+                .when()
+                .delete("/api/v1/applications/1")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    void cannot_delete_application_when_not_found() {
+        given()
+                .auth()
+                .oauth2(getAccessToken("alice"))
+                .when()
+                .delete("/api/v1/applications/12345")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void cannot_delete_application_when_not_same_applicant() {
+        given()
+                .auth()
+                .oauth2(getAccessToken("jdoe"))
+                .when()
+                .delete("/api/v1/applications/1")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    void cannot_delete_application_when_not_draft() {
+        given()
+                .auth()
+                .oauth2(getAccessToken("alice"))
+                .when()
+                .delete("/api/v1/applications/2")
+                .then()
+                .statusCode(409);
+    }
+
+    @Test
+    void cannot_delete_application_when_anonymous_request() {
+        given()
+                .when()
+                .delete("/api/v1/applications/1")
+                .then()
+                .statusCode(401);
+    }
+}

--- a/src/test/java/io/github/genomicdatainfrastructure/daam/api/SaveApplicationTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/daam/api/SaveApplicationTest.java
@@ -73,7 +73,7 @@ class SaveApplicationTest extends BaseTest {
                 .when()
                 .post("/api/v1/applications/2/save-forms-and-duos")
                 .then()
-                .statusCode(428);
+                .statusCode(409);
     }
 
     @Test

--- a/src/test/java/io/github/genomicdatainfrastructure/daam/api/SubmitApplicationTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/daam/api/SubmitApplicationTest.java
@@ -58,7 +58,7 @@ class SubmitApplicationTest extends BaseTest {
                 .when()
                 .post("/api/v1/applications/2/submit")
                 .then()
-                .statusCode(428);
+                .statusCode(409);
     }
 
     @Test

--- a/src/test/resources/mappings/delete_draft_application.json
+++ b/src/test/resources/mappings/delete_draft_application.json
@@ -1,0 +1,19 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/api/applications/delete",
+    "bodyPatterns": [
+      {
+        "equalToJson": {
+          "application-id": 1
+        }
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/src/test/resources/mappings/delete_draft_application.json.license
+++ b/src/test/resources/mappings/delete_draft_application.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 PNED G.I.E.
+
+SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add functionality to delete draft applications through a new API endpoint, update the OpenAPI specification, and implement corresponding tests to validate the feature.

New Features:
- Introduce a new API endpoint to delete draft applications, allowing users to remove applications that are in the draft state.

Enhancements:
- Update the OpenAPI specification to include the new delete application operation and adjust response codes for application state checks.

Tests:
- Add unit and integration tests for the delete application feature, ensuring correct behavior for various scenarios such as unauthorized access, non-existent applications, and applications not in draft state.

<!-- Generated by sourcery-ai[bot]: end summary -->