### PR TITLE
fix: change method from delete to post for deleting drafts

### DIFF
--- a/src/main/openapi/daam.yaml
+++ b/src/main/openapi/daam.yaml
@@ -85,43 +85,6 @@ paths:
       security:
         - daam_auth:
             - read:applications
-    delete:
-      summary: Delete application
-      operationId: delete_application_v1
-      tags:
-        - "application-command"
-      parameters:
-        - name: id
-          in: path
-          description: ID of application to delete
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        "204":
-          description: Successful Response (no content)
-        "403":
-          description: Application does not belong to applicant
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "404":
-          description: Application not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "409":
-          description: Application not in draft state
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-      security:
-        - daam_auth:
-            - read:applications
   /api/v1/applications/{id}/save-forms-and-duos:
     post:
       summary: save application forms and duos
@@ -210,6 +173,44 @@ paths:
       security:
         - daam_auth:
             - write:applications
+  /api/v1/applications/{id}/delete:
+    post:
+      summary: Delete application
+      operationId: delete_application_v1
+      tags:
+        - "application-command"
+      parameters:
+        - name: id
+          in: path
+          description: ID of application to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "204":
+          description: Successful Response (no content)
+        "403":
+          description: Application does not belong to applicant
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Application not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Application not in draft state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      security:
+        - daam_auth:
+            - read:applications
   /api/v1/applications/create:
     post:
       summary: Create application

--- a/src/test/java/io/github/genomicdatainfrastructure/daam/api/DeleteApplicationTest.java
+++ b/src/test/java/io/github/genomicdatainfrastructure/daam/api/DeleteApplicationTest.java
@@ -19,7 +19,7 @@ class DeleteApplicationTest extends BaseTest {
                 .auth()
                 .oauth2(getAccessToken("alice"))
                 .when()
-                .delete("/api/v1/applications/1")
+                .post("/api/v1/applications/1/delete")
                 .then()
                 .statusCode(204);
     }
@@ -30,7 +30,7 @@ class DeleteApplicationTest extends BaseTest {
                 .auth()
                 .oauth2(getAccessToken("alice"))
                 .when()
-                .delete("/api/v1/applications/12345")
+                .post("/api/v1/applications/12345/delete")
                 .then()
                 .statusCode(404)
                 .body("title", equalTo("Application Not Found"))
@@ -43,7 +43,7 @@ class DeleteApplicationTest extends BaseTest {
                 .auth()
                 .oauth2(getAccessToken("jdoe"))
                 .when()
-                .delete("/api/v1/applications/1")
+                .post("/api/v1/applications/1/delete")
                 .then()
                 .statusCode(403)
                 .body("title", equalTo("User Not Applicant"));
@@ -55,7 +55,7 @@ class DeleteApplicationTest extends BaseTest {
                 .auth()
                 .oauth2(getAccessToken("alice"))
                 .when()
-                .delete("/api/v1/applications/2")
+                .post("/api/v1/applications/2/delete")
                 .then()
                 .statusCode(409)
                 .body("title", equalTo("Application Not In Correct State"))
@@ -67,7 +67,7 @@ class DeleteApplicationTest extends BaseTest {
     void cannot_delete_application_when_anonymous_request() {
         given()
                 .when()
-                .delete("/api/v1/applications/1")
+                .post("/api/v1/applications/1/delete")
                 .then()
                 .statusCode(401);
     }


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the API to use POST instead of DELETE for deleting draft applications, and adjust the test cases to reflect this change.

Bug Fixes:
- Change the HTTP method for deleting drafts from DELETE to POST in the API specification and corresponding test cases.

<!-- Generated by sourcery-ai[bot]: end summary -->